### PR TITLE
Add the ability to require an age check to a request

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Environment Variables:
 - `USE_RECAPTCHA` - Whether to use Recaptcha v2 in the request flow to prevent bots; defaults to false.
 - `RECAPTCHA_SITE_KEY` - Required only if `USE_RECAPTCHA` is set to true
 - `RECAPTCHA_SECRET_KEY` - Required only if `USE_RECAPTCHA` is set to true
+- `AGE_MUST_BE_OVER_REQUIRED` - Whether or not you mandate the requesting user is over a certain age (set to `true` for yes)
+- `ADULT_AGE` - Configure the age for the `AGE_MUST_BE_OVER_REQUIRED` check (default `18`)
 
 *Notes*
 

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -129,6 +129,6 @@ class RequestsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def request_params
-      params.require(:request).permit(:email, :reason, :status, :query, :code_of_conduct)
+      params.require(:request).permit(:email, :reason, :status, :query, :code_of_conduct, :age_must_be_over)
     end
 end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -2,15 +2,16 @@
 #
 # Table name: requests
 #
-#  id              :bigint           not null, primary key
-#  email           :string
-#  reason          :text
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  status          :string           default("pending")
-#  deleted_at      :datetime
-#  ip              :string
-#  code_of_conduct :boolean          default(FALSE)
+#  id               :bigint           not null, primary key
+#  email            :string
+#  reason           :text
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  status           :string           default("pending")
+#  deleted_at       :datetime
+#  ip               :string
+#  code_of_conduct  :boolean          default(FALSE)
+#  age_must_be_over :boolean          default(FALSE)
 #
 
 class Request < ApplicationRecord
@@ -21,6 +22,7 @@ class Request < ApplicationRecord
   validate :reason_required
   validate :ban_check
   validate :code_of_conduct_check
+  validate :age_must_be_over_check
   validates :status, inclusion: { in: ['pending', 'approved', 'denied', 'deleted'] }
 
   scope :approved, -> { where status: 'approved' }
@@ -63,6 +65,12 @@ class Request < ApplicationRecord
   def code_of_conduct_check
     if ENV["CODE_OF_CONDUCT_REQUIRED"] == 'true' && code_of_conduct == false
       errors.add(:code_of_conduct, "must be agreed to")
+    end
+  end
+
+  def age_must_be_over_check
+    if ENV["AGE_MUST_BE_OVER_REQUIRED"] == 'true' && age_must_be_over == false
+      errors.add(:age_must_be_over, "#{ENV.fetch('ADULT_AGE', 18)}")
     end
   end
 end

--- a/app/views/requests/_form.html.erb
+++ b/app/views/requests/_form.html.erb
@@ -33,6 +33,16 @@
         </div>
       </div>
     <% end %>
+    <% if ENV["AGE_MUST_BE_OVER_REQUIRED"] == "true"%>
+      <div class="field">
+        <div class="control">
+          <label class="checkbox">
+            <%= form.check_box :age_must_be_over, class: "form-check-input" %>
+            I am over the age of <%= ENV.fetch('ADULT_AGE', 18) %> years
+          </label>
+        </div>
+      </div>
+    <% end %>
     <%= form.submit 'Submit', class: "button is-primary is-pulled-right" %>
   <% end %>
 </div>

--- a/db/migrate/20191215025110_add_age_must_be_over_to_request.rb
+++ b/db/migrate/20191215025110_add_age_must_be_over_to_request.rb
@@ -1,0 +1,5 @@
+class AddAgeMustBeOverToRequest < ActiveRecord::Migration[5.1]
+  def change
+    add_column :requests, :age_must_be_over, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171125005213) do
+ActiveRecord::Schema.define(version: 20191215025110) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,6 +54,7 @@ ActiveRecord::Schema.define(version: 20171125005213) do
     t.datetime "deleted_at"
     t.string "ip"
     t.boolean "code_of_conduct", default: false
+    t.boolean "age_must_be_over", default: false
     t.index ["deleted_at"], name: "index_requests_on_deleted_at"
   end
 

--- a/test/fixtures/requests.yml
+++ b/test/fixtures/requests.yml
@@ -2,15 +2,16 @@
 #
 # Table name: requests
 #
-#  id              :bigint           not null, primary key
-#  email           :string
-#  reason          :text
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  status          :string           default("pending")
-#  deleted_at      :datetime
-#  ip              :string
-#  code_of_conduct :boolean          default(FALSE)
+#  id               :bigint           not null, primary key
+#  email            :string
+#  reason           :text
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  status           :string           default("pending")
+#  deleted_at       :datetime
+#  ip               :string
+#  code_of_conduct  :boolean          default(FALSE)
+#  age_must_be_over :boolean          default(FALSE)
 #
 
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html

--- a/test/models/request_test.rb
+++ b/test/models/request_test.rb
@@ -2,15 +2,16 @@
 #
 # Table name: requests
 #
-#  id              :bigint           not null, primary key
-#  email           :string
-#  reason          :text
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  status          :string           default("pending")
-#  deleted_at      :datetime
-#  ip              :string
-#  code_of_conduct :boolean          default(FALSE)
+#  id               :bigint           not null, primary key
+#  email            :string
+#  reason           :text
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  status           :string           default("pending")
+#  deleted_at       :datetime
+#  ip               :string
+#  code_of_conduct  :boolean          default(FALSE)
+#  age_must_be_over :boolean          default(FALSE)
 #
 
 require 'test_helper'


### PR DESCRIPTION
# Purpose
For some slack groups, they may want to mandate all users be over a certain age. This give the capabilities to specify an age all members must be over.

# Features
- Optional age requirement
- Option to specify age