### PR TITLE
Add Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bin/rails server -p $PORT -e $RAILS_ENV
+release: rake db:migrate


### PR DESCRIPTION
# Purpose
This adds a procfile that will default the dynos in heroku, specifically this defines a `release` dyno that will run db migrations automatically instead of breaking the new release whenever there is a db change