### PR TITLE
Fix error on nil changed_by

### DIFF
--- a/app/views/bans/audit_log.html.erb
+++ b/app/views/bans/audit_log.html.erb
@@ -17,7 +17,7 @@
         <td><%= Ban.with_deleted.find(audit.auditable_id).ban_value %></td>
         <td><%= Ban.with_deleted.find(audit.auditable_id).ban_type %></td>
         <td><code><%= audit.audited_changes %></code></td>
-        <td><%= User.with_deleted.find(audit.user_id).email %></td>
+        <td><%= User.with_deleted.find_by_id(audit.user_id).try(:email).to_s %></td>
         <td><%= audit.created_at.to_formatted_s(:long)%></td>
       </tr>
     <% end %>

--- a/app/views/requests/audit_log.html.erb
+++ b/app/views/requests/audit_log.html.erb
@@ -15,7 +15,7 @@
       <tr>
         <td><%= Request.with_deleted.find(audit.auditable_id).email %></td>
         <td><code><%= audit.audited_changes %></code></td>
-        <td><%= User.with_deleted.find(audit.user_id).email %></td>
+        <td><%= User.with_deleted.find_by_id(audit.user_id).try(:email).to_s %></td>
         <td><%= audit.created_at.to_formatted_s(:long)%></td>
       </tr>
     <% end %>


### PR DESCRIPTION
# Purpose
We do not always have a user associated to a specific change, the prime example is when a user requests access, the `Request` is created, but no user is associated with that action. When that happens, we break the audit log because we try to do a lookup on a non existent `user_id`

This change will gracefully fail on a nil user lookup, and display no text for the `Changed By` column