### PR TITLE
Set flex-grow to 0 for proper center

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -87,6 +87,7 @@ footer {
 
 .container {
   padding-top: 24px;
+  flex-grow: 0;
 }
 
 h2 {


### PR DESCRIPTION
# Purpose
For reasons I do not know, setting `flex-grow` to `1` breaks the app and shoves the content to the top, this seems to fix it

# Current State
![image](https://user-images.githubusercontent.com/1581475/70878087-f5479d00-1f74-11ea-941b-168e5be06107.png)

# Fixed
![image](https://user-images.githubusercontent.com/1581475/70878113-0bedf400-1f75-11ea-854a-a2aeb66d89a0.png)
