### PR TITLE
Update Readme, rename age env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ Other slack auto-invite systems can cause issues by automatically allowing scamm
 - Approve or deny applicants
 - Blacklist domains/emails/IPs from being able to request access
 - Configurable required reason for joining
-- Customizable name and logo
+- Configurable age requirement agreement
 - Configurable Code of Conduct agreement
+- Customizable name and logo
 - Anti bot measures
 - Audit log for requests
 
@@ -48,7 +49,7 @@ Environment Variables:
 - `RECAPTCHA_SITE_KEY` - Required only if `USE_RECAPTCHA` is set to true
 - `RECAPTCHA_SECRET_KEY` - Required only if `USE_RECAPTCHA` is set to true
 - `AGE_MUST_BE_OVER_REQUIRED` - Whether or not you mandate the requesting user is over a certain age (set to `true` for yes)
-- `ADULT_AGE` - Configure the age for the `AGE_MUST_BE_OVER_REQUIRED` check (default `18`)
+- `AGE` - Configure the age for the `AGE_MUST_BE_OVER_REQUIRED` check (default `18`)
 
 *Notes*
 

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -70,7 +70,7 @@ class Request < ApplicationRecord
 
   def age_must_be_over_check
     if ENV["AGE_MUST_BE_OVER_REQUIRED"] == 'true' && age_must_be_over == false
-      errors.add(:age_must_be_over, "#{ENV.fetch('ADULT_AGE', 18)}")
+      errors.add(:age_must_be_over, "#{ENV.fetch('AGE', 18)}")
     end
   end
 end

--- a/app/views/requests/_form.html.erb
+++ b/app/views/requests/_form.html.erb
@@ -38,7 +38,7 @@
         <div class="control">
           <label class="checkbox">
             <%= form.check_box :age_must_be_over, class: "form-check-input" %>
-            I am over the age of <%= ENV.fetch('ADULT_AGE', 18) %> years
+            I am over the age of <%= ENV.fetch('AGE', 18) %> years
           </label>
         </div>
       </div>


### PR DESCRIPTION
# Purpose
- Update Readme to add age restriction functionality
- Rename age variable from`ADULT_AGE` to `AGE`

# Testing
- None Required 